### PR TITLE
Add .vercel to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 playwright-report
 test-results
+.vercel


### PR DESCRIPTION
This commit introduces .vercel to the .gitignore file. It's an important modification that will prevent unwanted tracking and sharing of .vercel files whenever changes are pushed to the repository.