### PR TITLE
Add pnpm version to package.json

### DIFF
--- a/.changeset/silver-shrimps-brush.md
+++ b/.changeset/silver-shrimps-brush.md
@@ -1,0 +1,5 @@
+---
+'prive': patch
+---
+
+Add pnpm version to package.json

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "prive",
 	"version": "0.0.6",
 	"private": true,
+	"engines": {
+		"pnpm": "^8.0.0"
+	},
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",


### PR DESCRIPTION
This commit adds a specific pnpm version to the engines field in the package.json file. This ensures that the project will use a predictable and stable version of pnpm.