### PR TITLE
Use 'await' in superValidate method

### DIFF
--- a/.changeset/new-pens-perform.md
+++ b/.changeset/new-pens-perform.md
@@ -1,0 +1,5 @@
+---
+'prive': patch
+---
+
+Use 'await' in superValidate method

--- a/src/routes/admin/clients/+page.server.ts
+++ b/src/routes/admin/clients/+page.server.ts
@@ -25,7 +25,7 @@ export const load: PageServerLoad = async (event: RequestEvent) => {
 
 	return {
 		clients: getClients(),
-		createClientForm: superValidate(clientSchema, {
+		createClientForm: await superValidate(clientSchema, {
 			id: 'createClient'
 		})
 	};

--- a/src/routes/admin/clients/[clientId]/+page.server.ts
+++ b/src/routes/admin/clients/[clientId]/+page.server.ts
@@ -1,5 +1,3 @@
-import { error, fail, redirect, type RequestEvent } from '@sveltejs/kit';
-import type { PageServerLoad, Actions } from './$types';
 import { error, fail, redirect, type ServerLoadEvent } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import { setError, superValidate } from 'sveltekit-superforms/server';

--- a/src/routes/login/+layout.server.ts
+++ b/src/routes/login/+layout.server.ts
@@ -9,6 +9,6 @@ export const load: PageServerLoad = async ({ locals }: PageServerLoadEvent) => {
 		throw redirect(302, '/');
 	}
 	return {
-		form: superValidate(loginSchema)
+		form: await superValidate(loginSchema)
 	};
 };

--- a/src/routes/register/+layout.server.ts
+++ b/src/routes/register/+layout.server.ts
@@ -9,6 +9,6 @@ export const load: PageServerLoad = async (event: PageServerLoadEvent) => {
 		throw redirect(302, '/');
 	}
 	return {
-		form: superValidate(registerSchema)
+		form: await superValidate(registerSchema)
 	};
 };


### PR DESCRIPTION
Implemented 'await' in superValidate method for form validation in login layout server. This change brings asynchronous handling to form validation, possibly enhancing performance and reliability in the validation process.