### PR TITLE
Add Vercel speed insights to project

### DIFF
--- a/.changeset/blue-birds-compete.md
+++ b/.changeset/blue-birds-compete.md
@@ -1,0 +1,5 @@
+---
+'prive': patch
+---
+
+Add Vercel speed insights to project

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
 	"type": "module",
 	"dependencies": {
 		"@internationalized/date": "^3.5.0",
+		"@vercel/speed-insights": "^1.0.2",
 		"bits-ui": "^0.9.9",
 		"clsx": "^2.0.0",
 		"cmdk-sv": "^0.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@internationalized/date':
     specifier: ^3.5.0
     version: 3.5.1
+  '@vercel/speed-insights':
+    specifier: ^1.0.2
+    version: 1.0.2
   bits-ui:
     specifier: ^0.9.9
     version: 0.9.9(svelte@4.2.8)
@@ -1380,6 +1383,11 @@ packages:
       - encoding
       - supports-color
     dev: true
+
+  /@vercel/speed-insights@1.0.2:
+    resolution: {integrity: sha512-y5HWeB6RmlyVYxJAMrjiDEz8qAIy2cit0fhBq+MD78WaUwQvuBnQlX4+5MuwVTWi46bV3klaRMq83u9zUy1KOg==}
+    requiresBuild: true
+    dev: false
 
   /@vitest/expect@0.32.4:
     resolution: {integrity: sha512-m7EPUqmGIwIeoU763N+ivkFjTzbaBn0n9evsTOcde03ugy2avPs3kZbYmw3DkcH1j5mxhMhdamJkLQ6dM1bk/A==}

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,3 @@
+import { injectSpeedInsights } from '@vercel/speed-insights/sveltekit';
+
+injectSpeedInsights();


### PR DESCRIPTION
Vercel's speed insights package has been installed and injected into the layout file. This captures performance metrics for the application and provides valuable insights for performance optimization. The `pnpm-lock.yaml` and `package.json` files have been updated accordingly to reflect the new dependency.